### PR TITLE
ClientLogin.verify() to return the result directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,10 +77,8 @@ module.exports = class AttestAuth {
   }
 }
 
-class ClientLogin extends EventEmitter {
+class ClientLogin {
   constructor ({ challenge, handshake, remotePublicKey, metadata }) {
-    super()
-
     this.challenge = challenge
     this.handshake = handshake
     this.remotePublicKey = remotePublicKey
@@ -96,12 +94,10 @@ class ClientLogin extends EventEmitter {
 
   verify (response) {
     try {
-      this.response = JSON.parse(this.handshake.recv(response))
+      return JSON.parse(this.handshake.recv(response))
     } catch (err) {
-      this.emit('error', err)
-      return
+      return { err }
     }
-    this.emit('verify', this.response)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attest-auth",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Login by attestation",
   "main": "index.js",
   "dependencies": {
@@ -12,7 +12,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "npx standard && tape test"
+    "test": "npx standard && tape test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
 const Authenticator = require('./')
 const curve = require('noise-handshake/dh')
-const sodium = require('sodium-native')
+const test = require('tape')
 
-const keypair = curve.generateKeypair()
-const serverKeys = curve.generateKeypair()
+const keypair = curve.generateKeyPair()
+const serverKeys = curve.generateKeyPair()
 
 const server = new Authenticator(serverKeys, { curve })
 
@@ -20,20 +20,13 @@ serverLogin.on('verify', function () {
 
 const trustedLogin = Authenticator.createClientLogin(
   keypair,
-  serverKeys.pub,
+  serverKeys.publicKey,
   serverLogin.challenge,
   {
     curve,
     metadata: Buffer.from('abcdef', 'hex')
   }
 )
-
-trustedLogin.on('verify', function (info) {
-  console.log(info.publicKey.slice(0, 8), 'logged in!')
-
-  const failedLogin = Authenticator.createClientLogin(keypair, serverKeys.pub, serverLogin.challenge, { curve })
-  serverLogin = server.verify(failedLogin.request) // throw error
-})
 
 serverLogin = server.verify(trustedLogin.request, {
   metadata: Buffer.from('123456', 'hex')
@@ -43,3 +36,20 @@ trustedLogin.verify(serverLogin.response)
 console.log('server client', serverLogin.clientMetadata)
 console.log('server server', serverLogin.serverMetadata)
 console.log('client client', trustedLogin.metadata)
+
+test('ClientLogin.verify() with invalid parameters', function (t) {
+  t.ok(trustedLogin.verify(null))
+  t.equal(
+    trustedLogin.verify(null).err.message,
+    'this.handshake.shift is not a function or its return value is not iterable'
+  )
+})
+
+test('ClientLogin.verify() with valid ServerLogin response', function (t) {
+  t.deepEqual(trustedLogin.verify(serverLogin.response), {
+    type: 'login',
+    publicKey: keypair.publicKey.toString('hex'),
+    description: 'Bitfinex',
+    metadata: 'EjRW'
+  })
+})


### PR DESCRIPTION
Update ClientLogin.verify() to return the result directly instead of emitting a `verify` event.